### PR TITLE
Fix coordinate names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cOSMos package for OSM data retrieval
-**cOSMos** is a thin wrapper for [OSM overpass API](http://wiki.openstreetmap.org/wiki/Overpass_API) that provides a number of helper functions to make downloading particular Open Street Map data easier. It allows to extract common features of interest (road networks, city locations, building footprints) based on location name. 
+**cOSMos** is a thin wrapper for [OSM overpass API](http://wiki.openstreetmap.org/wiki/Overpass_API) that provides a number of helper functions to make downloading particular Open Street Map data easier. It allows to extract common features of interest (road networks, city locations, building footprints) based on location name.
 
 # Install
 ```bash
@@ -28,11 +28,11 @@ roads = data.get('roads', 'Kuala Lumpur', format='geojson')
 
 Location defined by bbox.
 ```python
-west_lat = 47.3202203,
-south_lon =  8.6254413
-east_lat = 47.4346662
-north_lon = 8.4480061
-zurich = (west_lat, north_lon, east_lat, south_lon)
+south = 47.3202203,
+west = 8.4480061
+north = 47.4346662
+east = 8.6254413
+zurich = (south, west, north, east)
 
 # Without format argument it will return 2 generators with geometries and tags.
 buildings, tags = data.get('buildings', bbox=zurich)

--- a/cosmos/types.py
+++ b/cosmos/types.py
@@ -34,7 +34,7 @@ def building_query(bbox):
 def city_query(bbox):
     return JSON_QUERY_TEMPLATE.format(*(bbox + CITY_QUERY))
 
-BoundingBox = namedtuple('BoundingBox', ('left', 'top', 'right', 'bottom'))
+BoundingBox = namedtuple('BoundingBox', ('south', 'west', 'north', 'east'))
 
 DataType = {
     'roads': {

--- a/cosmos/utils.py
+++ b/cosmos/utils.py
@@ -56,18 +56,17 @@ def coords_for(name):
 
         # Coordinates have to be flipped in order to work in overpass
         if geometry.geom_type == 'Polygon':
-            top, left, bottom, right = geometry.bounds
-            return BoundingBox(left, top, right, bottom)
-
+            west, south, east, north = geometry.bounds
+            return BoundingBox(south, west, north, east)
         elif geometry.geom_type == 'MultiPolygon':
             bboxs = (BoundingBox(*(g.bounds[0:2][::-1] + g.bounds[2:][::-1]))
                      for g in geometry)
             return bboxs
         elif geometry.geom_type == 'Point':
-            left, right, top, bottom = (float(coordinate)
+            south, north, west, east = (float(coordinate)
                                         for coordinate in
                                         location.raw['boundingbox'])
-            return BoundingBox(left, top, right, bottom)
+            return BoundingBox(south, west, north, east)
 
     except (KeyError, AttributeError):
         raise AttributeError(


### PR DESCRIPTION
Fixes names used for coordinates to (south, west, north, east), following the [Overpass API convention](http://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#Bounding_box). 

PR also removes mixed use of (south, west, ...) and (bottom, left, ...).